### PR TITLE
test(core): test core modules

### DIFF
--- a/client/core/jest.config.js
+++ b/client/core/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/client/core/lib/Client.spec.ts
+++ b/client/core/lib/Client.spec.ts
@@ -1,0 +1,715 @@
+import { DynamicoClient } from './Client';
+
+class MockStorageProvider {
+  clear;
+  getItem = jest.fn();
+  setItem;
+  removeItem;
+  key;
+  length;
+  constructor() {
+    this.getItem = jest.fn();
+    this.setItem = jest.fn();
+  }
+}
+
+const testIssue = {
+  version: '1.0.0',
+  mismatches: {}
+};
+
+describe('Client tests', () => {
+  let consoleWarnSpy;
+  beforeEach(() => (consoleWarnSpy = jest.spyOn(global.console, 'warn')));
+  afterEach(() => consoleWarnSpy.mockRestore());
+
+  describe('constructor', () => {
+    afterEach(() => {
+      global['fetch'] = undefined;
+      global['window'] = undefined;
+    });
+
+    it('uses global fetch when there is one defined', () => {
+      const bind = jest.fn();
+      global['fetch'] = {
+        bind
+      };
+      global['window'] = {};
+      new DynamicoClient({
+        url: 'testUrl',
+        cache: new MockStorageProvider(),
+        dependencies: {
+          resolvers: {},
+          versions: {}
+        }
+      });
+      expect(bind).toBeCalled();
+    });
+    it('throws error when no fetcher is available', () => {
+      expect(
+        () =>
+          new DynamicoClient({
+            url: 'testUrl',
+            cache: new MockStorageProvider(),
+            dependencies: {
+              resolvers: {},
+              versions: {}
+            }
+          })
+      ).toThrow();
+    });
+  });
+
+  describe('initialize', () => {
+    it('prints out warning when registration response contains issues', async () => {
+      const url = 'testUrl';
+      const versions = {};
+      const request = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(versions)
+      };
+      const hostMismatchVersion = 'host version';
+      const componentMismatchVersion = 'component version';
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        json: () => Promise.resolve({ id: 'test_id', issues })
+      };
+      const componentName = 'test component';
+      const dependencyName = 'test dependency';
+      const issues = {
+        [componentName]: {
+          ...testIssue,
+          mismatches: {
+            [dependencyName]: {
+              host: hostMismatchVersion,
+              component: componentMismatchVersion
+            }
+          }
+        }
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageController = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        url,
+        cache: mockStroageController,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.initialize();
+
+      expect(mockFetch).toBeCalledWith(`${url}/host/register`, request);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        `${componentName}@${
+          issues[componentName].version
+        } requires ${dependencyName}@${componentMismatchVersion} but host provides ${hostMismatchVersion}. Please consider upgrade to version ${componentMismatchVersion}`
+      );
+    });
+
+    it('does not register dependency when a resolver is not provided for that dependency', async () => {
+      const url = 'testUrl';
+      const nonResolvedDep = 'nonResolvedDep';
+      const resolvedDep = 'resolvedDep';
+      const versions = {
+        [nonResolvedDep]: '1.0.0',
+        [resolvedDep]: '2.0.0'
+      };
+      const resolvers = { [resolvedDep]: () => 'test dependency' };
+      const expectedVersions = {
+        [resolvedDep]: '2.0.0'
+      };
+      const request = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(expectedVersions)
+      };
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        json: () => Promise.resolve({ id: 'test_id', issues })
+      };
+      const issues = {
+        testComponent: testIssue
+      };
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+      const mockStroageController = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        url,
+        cache: mockStroageController,
+        dependencies: {
+          resolvers,
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.initialize();
+
+      expect(mockFetch).toBeCalledWith(`${url}/host/register`, request);
+    });
+
+    it('does not register dependency and warns about it when only a resolver is provided', async () => {
+      const url = 'testUrl';
+      const versions = {
+        depA: '1.0.0'
+      };
+      const nonVersionedDep = 'nonVersionedDep';
+      const resolvers = Object.entries(versions).reduce(
+        (soFar, [key, version]) => ({ ...soFar, [key]: () => `${key}@${version}` }),
+        {}
+      );
+      resolvers[nonVersionedDep] = () => `${'nonVersionedDep'}`;
+      const request = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(versions)
+      };
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        json: () => Promise.resolve({ id: 'test_id', issues })
+      };
+      const issues = {
+        testComponent: testIssue
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+      const mockStroageController = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        url,
+        cache: mockStroageController,
+        dependencies: {
+          resolvers,
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.initialize();
+
+      expect(mockFetch).toBeCalledWith(`${url}/host/register`, request);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(`Missing version specifier for ${nonVersionedDep}`);
+    });
+
+    it(`registers host when called`, async () => {
+      const url = 'testUrl';
+      const versions = {};
+      const request = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(versions)
+      };
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        json: () => Promise.resolve({ id: 'test_id', issues })
+      };
+      const issues = {
+        testComponent: testIssue
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+      const mockStroageController = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        url,
+        cache: mockStroageController,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.initialize();
+
+      expect(mockFetch).toBeCalledWith(`${url}/host/register`, request);
+    });
+
+    it('throws error when registration request fails', async () => {
+      const url = 'testUrl';
+      const versions = {};
+      const mockFetch = jest.fn();
+      const expectedError = new Error('test error');
+      mockFetch.mockRejectedValue(expectedError);
+
+      const mockStroageController = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        url,
+        cache: mockStroageController,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await expect(client.initialize()).rejects.toEqual(expectedError);
+    });
+  });
+
+  describe('get', () => {
+    it('sends component version and component name to server when component version is specified and cache is empty', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const versions = {};
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve('true'),
+        headers: {
+          get: () => 'test_header'
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageController = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageController,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.get(componentName, { componentVersion });
+
+      expect(mockFetch).toBeCalledWith(`${url}/${componentName}?hostId=&componentVersion=${componentVersion}`);
+    });
+
+    it('sends component version and component name to server when component version is specified and cache is ignored', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const versions = {};
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve('true'),
+        headers: {
+          get: () => 'test_header'
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageController = new MockStorageProvider();
+      mockStroageController[`${prefix}/${componentName}/${componentVersion}`] = 'new code';
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageController,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.get(componentName, { ignoreCache: true, componentVersion });
+
+      expect(mockFetch).toBeCalledWith(`${url}/${componentName}?hostId=&componentVersion=${componentVersion}`);
+    });
+
+    it('gets component code from cache when component version is specified and a component by the same name exists in cache', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const versions = {};
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve('true'),
+        headers: {
+          get: () => 'test_header'
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageProvider = new MockStorageProvider();
+      mockStroageProvider[`${prefix}/${componentName}/${componentVersion}`] = 'new code';
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageProvider,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.get(componentName, { componentVersion });
+
+      expect(mockStroageProvider.getItem).toBeCalledWith(`${prefix}/${componentName}/${componentVersion}`);
+    });
+
+    it('sends latest component version and component name to server when a component by the same name exists in cache', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const versions = {};
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve('true'),
+        headers: {
+          get: () => 'test_header'
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageController = new MockStorageProvider();
+      mockStroageController[`${prefix}/${componentName}/${componentVersion}`] = 'new code';
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageController,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.get(componentName);
+
+      expect(mockFetch).toBeCalledWith(`${url}/${componentName}?hostId=&latestComponentVersion=${componentVersion}`);
+    });
+
+    it('saves new component code to cache when status code is 200', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const testCode = `var a = "test code"`;
+      const versions = {};
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve(testCode),
+        headers: {
+          get: () => componentVersion
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageProvider = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageProvider,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.get(componentName);
+
+      expect(mockStroageProvider.setItem).toBeCalledWith(`${prefix}/${componentName}/${componentVersion}`, testCode);
+    });
+
+    it('gets component from cache when status code is 204', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const testCode = `var a = "test code"`;
+      const versions = {};
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve(testCode),
+        headers: {
+          get: () => componentVersion
+        },
+        status: 204
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageProvider = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageProvider,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.get(componentName);
+      expect(mockStroageProvider.setItem).not.toBeCalled();
+      expect(mockStroageProvider.getItem).toBeCalledWith(`${prefix}/${componentName}/${componentVersion}`);
+    });
+
+    it('adds host id to request when initialized', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const expectedHostId = 'test_id';
+      const versions = {};
+      const mockFetch = jest.fn();
+
+      const issues = {
+        testComponent: testIssue
+      };
+
+      const mockRegisterResponse = {
+        json: () => Promise.resolve({ id: expectedHostId, issues })
+      };
+
+      const mockGetComponentResponse = {
+        text: () => Promise.resolve('true'),
+        headers: {
+          get: () => 'test_header'
+        },
+        status: 200
+      };
+      mockFetch
+        .mockReturnValueOnce(Promise.resolve(mockRegisterResponse))
+        .mockReturnValueOnce(Promise.resolve(mockGetComponentResponse));
+
+      const mockStroageController = new MockStorageProvider();
+      mockStroageController[`${prefix}/${componentName}/${componentVersion}`] = 'new code';
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageController,
+        dependencies: {
+          resolvers: {},
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.initialize();
+      await client.get(componentName);
+
+      expect(mockFetch).toBeCalledWith(
+        `${url}/${componentName}?hostId=${expectedHostId}&latestComponentVersion=${componentVersion}`
+      );
+    });
+
+    it('exposes dependency when provided in constructor', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const testCode = `require('dep')()`;
+      const dep = jest.fn();
+      const versions = { dep: '1.0.0' };
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve(testCode),
+        headers: {
+          get: () => componentVersion
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageProvider = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageProvider,
+        dependencies: {
+          resolvers: {
+            dep
+          },
+          versions
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.get(componentName);
+
+      expect(dep).toBeCalled();
+    });
+
+    it('exposes globals when provided in constructor', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const someGlobal = jest.fn();
+      const testCode = `someGlobal()`;
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve(testCode),
+        headers: {
+          get: () => componentVersion
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageProvider = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageProvider,
+        dependencies: {
+          resolvers: {},
+          versions: {}
+        },
+        globals: {
+          someGlobal
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.get(componentName);
+
+      expect(someGlobal).toBeCalled();
+    });
+
+    it('overrides globals from ctor when provided in get options', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const ctorGlobal = jest.fn();
+      const getGlobal = jest.fn();
+      const testCode = `someGlobal()`;
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve(testCode),
+        headers: {
+          get: () => componentVersion
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageProvider = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageProvider,
+        dependencies: {
+          resolvers: {},
+          versions: {}
+        },
+        globals: {
+          someGlobal: ctorGlobal
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      await client.get(componentName, {
+        globals: { someGlobal: getGlobal }
+      });
+
+      expect(getGlobal).toBeCalled();
+      expect(ctorGlobal).not.toBeCalled();
+    });
+
+    it('evaluates and returns module export when fetched code uses module.exports form and ignores exports.default', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const moduleExportsValue = 'test module.exports';
+      const exportsDefaultValue = 'should not be this';
+      const testCode = `
+      exports.default = '${exportsDefaultValue}';
+        module.exports = '${moduleExportsValue}';`;
+
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve(testCode),
+        headers: {
+          get: () => componentVersion
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageProvider = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageProvider,
+        dependencies: {
+          resolvers: {},
+          versions: {}
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      const result = await client.get(componentName);
+
+      expect(result).toEqual(moduleExportsValue);
+    });
+
+    it('evaluates and returns exports.default when fetched code uses exports.default and not module.exports', async () => {
+      const url = 'testUrl';
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+
+      const exportsDefaultValue = 'test exports.default';
+      const testCode = `
+      exports.default = '${exportsDefaultValue}';`;
+
+      const mockFetch = jest.fn();
+      const mockResponse = {
+        text: () => Promise.resolve(testCode),
+        headers: {
+          get: () => componentVersion
+        },
+        status: 200
+      };
+
+      mockFetch.mockReturnValue(Promise.resolve(mockResponse));
+
+      const mockStroageProvider = new MockStorageProvider();
+
+      const client = new DynamicoClient({
+        prefix,
+        url,
+        cache: mockStroageProvider,
+        dependencies: {
+          resolvers: {},
+          versions: {}
+        },
+        fetcher: mockFetch as GlobalFetch['fetch']
+      });
+      const result = await client.get(componentName);
+
+      expect(result).toEqual(exportsDefaultValue);
+    });
+  });
+});

--- a/client/core/lib/Client.ts
+++ b/client/core/lib/Client.ts
@@ -36,6 +36,11 @@ export interface Options {
   globals?: Record<string, any>;
 }
 
+interface RegisterHostResponse {
+  id: string;
+  issues: Issues;
+}
+
 export class DynamicoClient {
   id: string = '';
   url: string;
@@ -56,14 +61,6 @@ export class DynamicoClient {
     this.checkFetcher(options.fetcher);
 
     this.fetcher = options.fetcher || fetch.bind(window);
-
-    const versions = this.filterMissingDependencies(options.dependencies);
-
-    this.register(versions).then(({ id, issues }: { id: string; issues: Issues }) => {
-      this.id = id;
-
-      this.handleIssues(issues);
-    });
   }
 
   private handleIssues(issues: Issues): void {
@@ -150,6 +147,13 @@ export class DynamicoClient {
     await this.cache.setItem(name, version, code);
 
     return code;
+  }
+
+  async initialize() {
+    const versions = this.filterMissingDependencies(this.dependencies);
+    const { id, issues }: RegisterHostResponse = await this.register(versions);
+    this.id = id;
+    this.handleIssues(issues);
   }
 
   async get(name: string, options: Options = {}) {

--- a/client/core/lib/utils/StorageController.spec.ts
+++ b/client/core/lib/utils/StorageController.spec.ts
@@ -1,0 +1,118 @@
+import { StorageController } from './StorageController';
+
+class MockStorage {
+  clear;
+  getItem = jest.fn();
+  setItem;
+  removeItem;
+  key;
+  length;
+  constructor() {
+    this.getItem = jest.fn();
+    this.setItem = jest.fn();
+  }
+}
+
+describe('StorageControllerTests', () => {
+  describe('getStorageKey', () => {
+    it('returns storage key with prefix when providing component name and version', () => {
+      const storageController = new StorageController('test_prefix', new MockStorage());
+      const key = storageController.getStorageKey('component_test', 'version_test');
+      expect(key).toMatch(/^test_prefix/);
+    });
+
+    it('returns different keys when using different component names', () => {
+      const storageController = new StorageController('test_prefix', new MockStorage());
+      const key1 = storageController.getStorageKey('component_test_a', 'version_test');
+      const key2 = storageController.getStorageKey('component_test_b', 'version_test');
+      expect(key1).not.toEqual(key2);
+    });
+
+    it('returns different keys when using different component versions', () => {
+      const storageController = new StorageController('test_prefix', new MockStorage());
+      const key1 = storageController.getStorageKey('component_test_a', 'version_test_1');
+      const key2 = storageController.getStorageKey('component_test_a', 'version_test_2');
+      expect(key1).not.toEqual(key2);
+    });
+  });
+
+  describe('has', () => {
+    it('returns false when storage is empty', () => {
+      const storageController = new StorageController('test', new MockStorage());
+      const has = storageController.has('component_test', 'version_test');
+      expect(has).toBe(false);
+    });
+
+    it('returns true for component that exists in storage', () => {
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const mockStorage = new MockStorage();
+      mockStorage[`${prefix}/${componentName}/${componentVersion}`] = 'my component';
+      const storageController = new StorageController(prefix, mockStorage);
+      const has = storageController.has(componentName, componentVersion);
+
+      expect(has).toBe(true);
+    });
+  });
+
+  describe('getItem', () => {
+    it('retrieves component from storage by key when provided existing component name and version', async () => {
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const mockStorage = new MockStorage();
+      const componentCode = 'test code';
+      mockStorage.getItem.mockReturnValue(componentCode);
+
+      const storageController = new StorageController(prefix, mockStorage);
+      const result = await storageController.getItem(componentName, componentVersion);
+      const key = storageController.getStorageKey(componentName, componentVersion);
+      expect(mockStorage.getItem).toHaveBeenCalledWith(key);
+      expect(result).toEqual(componentCode);
+    });
+  });
+
+  describe('setItem', () => {
+    it('saves component code to storage by key when code and component name and version are provided', async () => {
+      const componentName = 'component_test';
+      const componentVersion = 'version_test';
+      const prefix = 'test';
+      const mockStorage = new MockStorage();
+      mockStorage.setItem.mockReturnValue(Promise.resolve());
+      const componentCode = 'test code';
+      const storageController = new StorageController(prefix, mockStorage);
+      await storageController.setItem(componentName, componentVersion, componentCode);
+      const key = storageController.getStorageKey(componentName, componentVersion);
+      expect(mockStorage.setItem).toBeCalledWith(key, componentCode);
+    });
+  });
+
+  describe('getLatestVersion', () => {
+    it('returns the latest version number when there are more than one version available', () => {
+      const componentName = 'component_test';
+      const earlierVersion = '0.0.1';
+      const latestVersion = '1.0.0';
+      const prefix = 'test';
+      const mockStorage = new MockStorage();
+      mockStorage[`${prefix}/${componentName}/${earlierVersion}`] = 'old code';
+      mockStorage[`${prefix}/${componentName}/${latestVersion}`] = 'new code';
+
+      const storageController = new StorageController(prefix, mockStorage);
+      const result = storageController.getLatestVersion(componentName);
+
+      expect(result).not.toEqual(earlierVersion);
+      expect(result).toEqual(latestVersion);
+    });
+    it('returns undefined for empty storage', () => {
+      const componentName = 'component_test';
+      const prefix = 'test';
+      const mockStorage = new MockStorage();
+
+      const storageController = new StorageController(prefix, mockStorage);
+      const result = storageController.getLatestVersion(componentName);
+
+      expect(result).not.toBeDefined();
+    });
+  });
+});

--- a/client/core/package.json
+++ b/client/core/package.json
@@ -7,11 +7,13 @@
   "scripts": {
     "build": "npm run clean && npm run compile",
     "compile": "tsc",
-    "clean": "rm -rf ./dist"
+    "clean": "rm -rf ./dist",
+    "test": "jest --coverage"
   },
   "devDependencies": {
     "@types/compare-versions": "^3.0.0",
     "@types/deepmerge": "^2.2.0",
+    "ts-jest": "^24.0.2",
     "ts-lint": "^4.5.1",
     "typescript": "^3.3.3333"
   },

--- a/examples/react/index.tsx
+++ b/examples/react/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import * as ReactDOM from 'react-dom';
 import moment from 'moment';
 
@@ -24,18 +24,26 @@ const resolvers = {
   moment: moment
 };
 
-const App = () => {
-  const dynamico = new DynamicoClient({
-    url: '/api/components',
-    dependencies: {
-      versions: dependencies,
-      resolvers
-    },
-    cache: localStorage
-  });
+const dynamicoClient = new DynamicoClient({
+  url: '/api/components',
+  dependencies: {
+    versions: dependencies,
+    resolvers
+  },
+  cache: localStorage
+});
 
+const App = () => {
+  const [initFinished, setInitFinished] = useState(false);
+
+  useEffect(() => {
+    dynamicoClient.initialize().then(() => setInitFinished(true));
+  }, []);
+
+  
+  if (!initFinished) return (<div>Loading...</div>);
   return (
-    <DynamicoProvider client={dynamico}>
+    <DynamicoProvider client={dynamicoClient}>
       <MyComp username="Test">
         <span>testSpan</span>
       </MyComp>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10326,6 +10326,21 @@ ts-jest@^24.0.0:
     semver "^5.5"
     yargs-parser "10.x"
 
+ts-jest@^24.0.2:
+  version "24.0.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"
+  integrity sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    resolve "1.x"
+    semver "^5.5"
+    yargs-parser "10.x"
+
 ts-lint@^4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/ts-lint/-/ts-lint-4.5.1.tgz#9c22b7b7b862b67324dd1bd213a845c03a7fb8c0"


### PR DESCRIPTION
Test core modules.

From writing the tests for the client code I realize we should refactor it and make it a bit more modular. Separate the fetching of the code from its evaluation. Will also open some more options (dynamic module imports maybe?)