### PR TITLE
fix(express-middleware): replace hash alg for host id

### DIFF
--- a/examples/react/components/index.json
+++ b/examples/react/components/index.json
@@ -1,1 +1,1 @@
-{"c0afaaf2b7043a663698b46768d34ebf":{"dependencies":{"react":"^16.8.3","react-dom":"^16.8.3","moment":"^2.24.0"},"components":{"mycomp":"1.0.1"}}}
+{"543330903":{"dependencies":{"react":"^16.8.3","react-dom":"^16.8.3","moment":"^2.24.0"},"components":{"mycomp":"1.0.1"}},"c0afaaf2b7043a663698b46768d34ebf":{"dependencies":{"react":"^16.8.3","react-dom":"^16.8.3","moment":"^2.24.0"},"components":{"mycomp":"1.0.1"}}}

--- a/server/driver/lib/index.ts
+++ b/server/driver/lib/index.ts
@@ -1,7 +1,7 @@
 import compareVersions from 'compare-versions';
 import semver from 'semver';
 import { Stream } from 'stream';
-import md5 from 'md5';
+import MurmurHash3 from 'imurmurhash';
 
 import {
   NoComponentError,
@@ -75,7 +75,7 @@ export class Driver {
     let issues = {};
 
     const sortedDependencies = Object.entries(dependencies).sort(([nameA], [nameB]) => nameA.localeCompare(nameB));
-    const id = md5(JSON.stringify(sortedDependencies));
+    const id = MurmurHash3(JSON.stringify(sortedDependencies)).result();
 
     const index = this.storage.getIndex();
 

--- a/server/driver/package.json
+++ b/server/driver/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "compare-versions": "^3.4.0",
-    "md5": "^2.2.1",
+    "imurmurhash": "^0.1.4",
     "semver": "^6.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2672,11 +2672,6 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
-charenc@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
-
 chokidar@^2.0.3, chokidar@^2.0.4:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.2.tgz#9c23ea40b01638439e0513864d362aeacc5ad058"
@@ -3270,11 +3265,6 @@ cross-spawn@^5.0.1:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-crypt@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
-  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -5292,7 +5282,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -6689,15 +6679,6 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
-
-md5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
-  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
-  dependencies:
-    charenc "~0.0.1"
-    crypt "~0.0.1"
-    is-buffer "~1.1.1"
 
 mdn-data@~1.1.0:
   version "1.1.4"


### PR DESCRIPTION
As part of @omerlh 's code review he noted that using md5 for hashing might not be the best option. I couldn't find any documentation that helped me to choose a different algorithm. I went with sha256. If you can consult on how to choose that'll be great. Otherwise we can move forward with this I think.