### PR TITLE
fix(express-middleware): add parameter sanitization

### DIFF
--- a/server/express-middleware/lib/controller.ts
+++ b/server/express-middleware/lib/controller.ts
@@ -3,11 +3,20 @@ import { Driver, File } from '@dynamico/driver';
 import tar from 'tar-stream';
 import zlib from 'zlib';
 import intoStream from 'into-stream';
+import { valid, clean } from 'semver';
+import sanitizeFilename from 'sanitize-filename';
 import { Stream } from 'stream';
 import promisePipe from 'promisepipe';
+import { InvalidVersionError } from './errors';
 
 export const get = (driver: Driver) => (req: Request, res: Response) => {
-  const { name } = req.params;
+  if (req.query.componentVersion && !valid(req.query.componentVersion)) {
+    throw new InvalidVersionError({ componentVersion: req.query.componentVersion });
+  }
+  if (req.query.latestComponentVersion && !valid(req.query.latestComponentVersion)) {
+    throw new InvalidVersionError({ latestVersion: req.query.latestComponentVersion });
+  }
+  const name = sanitizeFilename(req.params.name);
   const { hostId, componentVersion, latestComponentVersion } = req.query;
 
   const { version, getCode } = driver.getComponent({
@@ -28,14 +37,18 @@ export const get = (driver: Driver) => (req: Request, res: Response) => {
 export const registerHost = (driver: Driver) => async (req: Request) => driver.registerHost(req.body);
 
 export const save = (driver: Driver) => async (req: Request, res: Response) => {
-  const { name, componentVersion } = req.params;
+  const name = sanitizeFilename(req.params.name);
+  if (!valid(req.params.componentVersion)) {
+    throw new InvalidVersionError({ componentVersion: req.params.componentVersion });
+  }
+  let componentVersion = clean(req.params.componentVersion) as string;
   const files: File[] = [];
 
   await promisePipe(
     intoStream(req.file.buffer),
     zlib.createGunzip(),
     tar.extract().on('entry', (header, stream: Stream, next) => {
-      files.push({ name: header.name, stream: stream.on('finish', next) });
+      files.push({ name: sanitizeFilename(header.name), stream: stream.on('finish', next) });
     })
   );
 

--- a/server/express-middleware/lib/errors.ts
+++ b/server/express-middleware/lib/errors.ts
@@ -1,0 +1,13 @@
+class BaseError extends Error {
+  constructor(message: string, public data: any) {
+    super(message);
+  }
+}
+
+export class InvalidVersionError extends BaseError {
+  constructor(data: any) {
+    super(`Invalid version string`, data);
+
+    this.name = 'InvalidVersionString';
+  }
+}

--- a/server/express-middleware/package.json
+++ b/server/express-middleware/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "npm run clean && npm run compile",
     "compile": "tsc",
-    "test": "jest",
+    "test": "jest --coverage",
     "clean": "rm -rf ./dist"
   },
   "bugs": {
@@ -28,11 +28,15 @@
   },
   "dependencies": {
     "@dynamico/driver": "^0.0.1",
+    "@types/sanitize-filename": "^1.1.28",
+    "@types/semver": "^6.0.0",
     "express-async-router": "^0.1.15",
     "into-stream": "^5.0.0",
     "multer": "^1.4.1",
     "promisepipe": "^3.0.0",
     "pump": "^3.0.0",
+    "sanitize-filename": "^1.6.1",
+    "semver": "^6.0.0",
     "tar": "^4.4.8",
     "tar-stream": "^2.0.1"
   },


### PR DESCRIPTION
added some basic parameter sanitation in the controller. I force component versions to be semver and component name to be a valid file name. Also I clean up the uploaded file names. This is quite basic and every storage provider will have to provide further safety checks and sanitation for the specific storage solution (i.e. SQL injection prevention or non-SQL injection for MongoDB etc.)