### PR TITLE
fix (core): skip save when get component requests response is not ok

### DIFF
--- a/client/core/lib/errors.ts
+++ b/client/core/lib/errors.ts
@@ -1,0 +1,11 @@
+class BaseError extends Error {
+  constructor(message: string, public data: any) {
+    super(message);
+  }
+}
+
+export class ComponentGetFailedError extends BaseError {
+  constructor(message: string, response: Response) {
+    super(message, response);
+  }
+}


### PR DESCRIPTION
* followed the Fetch API and used the `response.ok` property that is set to false when the status code is bigger than 299
* added custom error which is thrown along with the response object and the response text
* added tests
fixes #32