### PR TITLE
(fix): Azure blobs download

### DIFF
--- a/client/core/lib/Client.ts
+++ b/client/core/lib/Client.ts
@@ -188,7 +188,9 @@ export class DynamicoClient {
     const { id, issues }: RegisterHostResponse = await this.register(versions);
 
     this.id = id;
-    this.handleIssues(issues);
+    if (issues) {
+      this.handleIssues(issues);
+    }
   }
 
   async get(name: string, options: Options = {}) {

--- a/server/azure-blob-storage/lib/index.spec.ts
+++ b/server/azure-blob-storage/lib/index.spec.ts
@@ -6,7 +6,7 @@ import intoStream = require('into-stream');
 
 describe('AzureBlobStorage', () => {
   const createBlobMock = (path: string, contents: string) => {
-    const mockedResult = { readableStreamBody: { read: () => contents }, contentLength: 2 };
+    const mockedResult = { readableStreamBody: intoStream(contents), contentLength: 2 };
     const blobUrl = {
       download: jest.fn().mockResolvedValueOnce(mockedResult)
     };
@@ -98,7 +98,7 @@ describe('AzureBlobStorage', () => {
         }
       };
       const indexBlobName = 'some index file name';
-      const mockedResult = { readableStreamBody: { read: () => JSON.stringify(existingIndex) }, contentLength: 2 };
+      const mockedResult = { readableStreamBody: intoStream(JSON.stringify(existingIndex)), contentLength: 2 };
       const blobUrl = {
         indexBlobName,
         download: jest.fn().mockResolvedValueOnce(mockedResult)
@@ -132,7 +132,7 @@ describe('AzureBlobStorage', () => {
         }
       };
       const indexBlobName = 'some index file name';
-      const mockedResult = { readableStreamBody: { read: () => JSON.stringify(existingIndex) }, contentLength: 2 };
+      const mockedResult = { readableStreamBody: intoStream(JSON.stringify(existingIndex)), contentLength: 2 };
       const blobUrl = {
         indexBlobName,
         download: jest.fn().mockResolvedValueOnce(mockedResult)
@@ -195,7 +195,7 @@ describe('AzureBlobStorage', () => {
         }
       };
       const indexBlobName = 'some index file name';
-      const mockedResult = { readableStreamBody: { read: () => JSON.stringify(existingIndex) }, contentLength: 2 };
+      const mockedResult = { readableStreamBody: intoStream(JSON.stringify(existingIndex)), contentLength: 2 };
       const blobUrl = {
         indexBlobName,
         download: jest.fn().mockResolvedValueOnce(mockedResult)

--- a/server/azure-blob-storage/package.json
+++ b/server/azure-blob-storage/package.json
@@ -2,7 +2,8 @@
   "name": "@dynamico/azure-blob-storage",
   "version": "0.0.1-alpha.4",
   "description": "Azure blob storage implementation as Dynamico storage provider",
-  "main": "index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest",
     "coverage": "jest --coverage",


### PR DESCRIPTION
 - Use correct stream API
 - Don’t crash in client when there are no issues from the server

Tried it locally and fixed issues that prevented me from using it correctly