### PR TITLE
feat(express-middleware): add support for custom router

### DIFF
--- a/server/express-middleware/lib/index.spec.ts
+++ b/server/express-middleware/lib/index.spec.ts
@@ -1,0 +1,32 @@
+import controllerBuilder from '.';
+
+describe('index', () => {
+  describe('constructor', () => {
+    it('should use router arguments when provided', async () => {
+      const mockRouter = {
+        get: jest.fn(),
+        post: jest.fn(),
+        use: jest.fn()
+      };
+
+      controllerBuilder({} as any, { router: mockRouter as any });
+
+      expect(mockRouter.get).toBeCalledTimes(1);
+      expect(mockRouter.post).toBeCalledTimes(2);
+      expect(mockRouter.use).toBeCalledTimes(1);
+    });
+    it('should not set up more than one post route and not call use when set to readOnly', () => {
+      const mockRouter = {
+        get: jest.fn(),
+        post: jest.fn(),
+        use: jest.fn()
+      };
+
+      controllerBuilder({} as any, { readOnly: true, router: mockRouter as any });
+
+      expect(mockRouter.get).toBeCalledTimes(1);
+      expect(mockRouter.post).toBeCalledTimes(1);
+      expect(mockRouter.use).not.toBeCalled();
+    });
+  });
+});

--- a/server/express-middleware/lib/index.ts
+++ b/server/express-middleware/lib/index.ts
@@ -10,10 +10,10 @@ const upload = multer({ storage: storage });
 
 interface Options {
   readOnly?: boolean;
+  router?: AsyncRouterInstance;
 }
 
-export default (storage: Storage, { readOnly }: Options = {}): AsyncRouterInstance => {
-  const router = AsyncRouter();
+export default (storage: Storage, { readOnly, router = AsyncRouter() }: Options = {}): AsyncRouterInstance => {
   const driver = new Driver(storage);
 
   router.post('/host/register', bodyParser.json(), controller.registerHost(driver));


### PR DESCRIPTION
* Add ability to pass custom router in options to the controller creator
This will allow us to add a rate limiting middleware (or any other middleware of the user's choice)
Downside of this solution is that the consumer has to know the actual routes to provide route-specific middlewares etc. Is there a better API we can provide?