### PR TITLE
feat(cli): Add the option to extend Rollup config used by dcm

### DIFF
--- a/client/cli/README.md
+++ b/client/cli/README.md
@@ -133,6 +133,10 @@ The base URL of the dynamico components registry.
 
 Middleware for the publish api, transform the request just before sending the code to the registry. This is where you can add authentication settings (e.g. API key).
 
+##### modifyRollupConfig
+* Type: `Function`
+Use this function to modify the Rollup config used by `dcm`. You can use this function to add Rollup plugins. Read more [here](https://rollupjs.org/guide/en/#rolluprollup).
+
 #### NOTE
 
 Since we use [Liftoff](https://github.com/js-cli/js-liftoff),

--- a/client/cli/lib/build.ts
+++ b/client/cli/lib/build.ts
@@ -1,4 +1,5 @@
 import { Bundler } from 'bili';
+import { ExtendRollupConfig } from 'bili/types/types';
 import { basename, extname, resolve } from 'path';
 import { writeFile, mkdirSync, existsSync } from 'fs';
 import { promisify } from 'util';
@@ -13,14 +14,16 @@ export const enum Mode {
   development = 'development'
 }
 
-interface Options {
+export interface Options {
   mode?: Mode;
   file?: string;
+  modifyRollupConfig?: ExtendRollupConfig;
 }
 
-export default async ({ mode = Mode.development, file = getMainFile() }: Options = {}): Promise<any> => {
+export default async ({ mode = Mode.development, file = getMainFile(), modifyRollupConfig }: Options = {}): Promise<
+  any
+> => {
   const isProd = mode === Mode.production;
-
   const bundler = new Bundler({
     input: resolve(process.cwd(), file),
     bundleNodeModules: true,
@@ -33,7 +36,8 @@ export default async ({ mode = Mode.development, file = getMainFile() }: Options
     },
     output: {
       minify: isProd
-    }
+    },
+    extendRollupConfig: modifyRollupConfig
   });
 
   const packageJson = getPackageJson();

--- a/client/cli/lib/index.ts
+++ b/client/cli/lib/index.ts
@@ -1,4 +1,4 @@
 export { default as init } from './init';
 export { default as start, DEFAULT_PORT as DEFAULT_DEV_PORT } from './start';
-export { default as build, Mode as BuildMode } from './build';
+export { default as build, Mode as BuildMode, Options as BuildOptions } from './build';
 export { default as publish } from './publish';

--- a/client/cli/lib/publish.ts
+++ b/client/cli/lib/publish.ts
@@ -4,16 +4,16 @@ import { createReadStream, createWriteStream, unlinkSync } from 'fs';
 import tar from 'tar';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import build, { Mode } from './build';
+import build, { Mode, Options } from './build';
 import urlJoin from 'url-join';
 import promisePipe from 'promisepipe';
 
-export default async (basePath: string, middleware?: Function) => {
+export default async (basePath: string, middleware?: Function, buildOptions?: Options) => {
   const body = new FormData();
   const filename = `dcmtmp${new Date().getTime()}.tgz`;
   const file = join(tmpdir(), filename);
 
-  const { name, version, main, peerDependencies } = await build({ mode: Mode.production });
+  const { name, version, main, peerDependencies } = await build({ ...buildOptions, mode: Mode.production });
 
   await promisePipe(tar.create({ gzip: true, cwd: './dist' }, [main, 'package.json']), createWriteStream(file));
 

--- a/client/cli/lib/start.ts
+++ b/client/cli/lib/start.ts
@@ -1,13 +1,13 @@
 import * as liveServer from 'live-server';
 import bodyParser from 'body-parser';
 
-import build from './build';
+import build, { Options } from './build';
 import { validateDependencies } from './utils';
 
 export const DEFAULT_PORT = 8383;
 
-export default async ({ port = DEFAULT_PORT }): Promise<any> => {
-  const { main, peerDependencies } = await build();
+export default async ({ port = DEFAULT_PORT }, buildOptions?: Options): Promise<any> => {
+  const { main, peerDependencies } = await build(buildOptions);
 
   return liveServer.start({
     port,

--- a/client/cli/src/actions/build.ts
+++ b/client/cli/src/actions/build.ts
@@ -1,11 +1,15 @@
 import { STRING } from 'caporal';
 import { registerCommand } from '../util';
-import { build, BuildMode } from '../../lib';
+import { build, BuildMode, BuildOptions } from '../../lib';
+import { DcmConfig } from '..';
 
-export default () =>
+export default (config: DcmConfig) =>
   registerCommand({
     name: 'build',
     description: 'Build dynamic component',
     options: [['-m, --mode <mode>', 'mode', STRING, BuildMode.development], ['-f --file <file>', 'file', STRING]],
-    action: ({ options: { mode } }) => build({ mode })
+    action: ({ options: { mode } }) => {
+      let buildConfig: BuildOptions = { mode, modifyRollupConfig: config && config.modifyRollupConfig };
+      return build(buildConfig);
+    }
   });

--- a/client/cli/src/actions/publish.ts
+++ b/client/cli/src/actions/publish.ts
@@ -19,7 +19,7 @@ export default (config: DcmConfig) =>
 
       logger.info('Publishing...');
 
-      return publish(url || config.registry, config.middleware)
+      return publish(url || config.registry, config.middleware, { modifyRollupConfig: config.modifyRollupConfig })
         .then(({ name, version }: any) => logger.info(`Successfully published ${name}@${version}`))
         .catch(({ message }) => logger.error(message));
     }

--- a/client/cli/src/actions/start.ts
+++ b/client/cli/src/actions/start.ts
@@ -1,11 +1,13 @@
 import { INT } from 'caporal';
 import { registerCommand } from '../util';
 import { start, DEFAULT_DEV_PORT } from '../../lib';
+import { DcmConfig } from '..';
 
-export default () =>
+export default (config: DcmConfig) =>
   registerCommand({
     name: 'start',
     description: 'Start dynamic component dev server',
     options: [['-p, --port <port>', `dev server port`, INT, DEFAULT_DEV_PORT]],
-    action: ({ options: { port } }) => start({ port })
+    action: ({ options: { port }, logger }) =>
+      start({ port }, config && { modifyRollupConfig: config.modifyRollupConfig })
   });

--- a/client/cli/src/index.ts
+++ b/client/cli/src/index.ts
@@ -1,5 +1,6 @@
 import Liftoff from 'liftoff';
 import program from 'caporal';
+import { ExtendRollupConfig } from 'bili/types/types';
 import { jsVariants } from 'interpret';
 import { tmpdir } from 'os';
 
@@ -18,6 +19,7 @@ program
 export interface DcmConfig {
   registry: string;
   middleware?: Function;
+  modifyRollupConfig?: ExtendRollupConfig;
 }
 
 const Dcm = new Liftoff({


### PR DESCRIPTION
* Added the `modifyRollupConfig` property to the exported configuration object from `dcmconfig.js` which takes a function that gets a RollupConfig object and returns a RollupConfig object.