### PR TITLE
feat(core): Add support for integrity check

### DIFF
--- a/client/core/lib/errors.ts
+++ b/client/core/lib/errors.ts
@@ -9,3 +9,9 @@ export class ComponentGetFailedError extends BaseError {
     super(message, response);
   }
 }
+
+export class ComponentIntegrityCheckFailed extends BaseError {
+  constructor(component: { name: string; version: string }) {
+    super('Integrity check failed', component);
+  }
+}


### PR DESCRIPTION
* Allow to pass in  the client's `InitOptions` an async function that will return a boolean response of whether or not we should evaluate the code.
* This can allow consumers to run integrity checks or implement code signing mechanisms of their own.
* If the check fails the fetch process will throw an error and the code won't be evaluated and will not be saved to cache.
* Code that's fetched from the cache is considered safe and so we don't run this check on it.