### PR TITLE
feat(dockerfiles): add support to docker secrets for configs (#58)

### DIFF
--- a/dockerfiles/azure-blobs-storage/README.md
+++ b/dockerfiles/azure-blobs-storage/README.md
@@ -21,5 +21,12 @@ To configure the server you can use these environment variables:
     - Set the port on which the server will listen to. Defaults to `1234`.
 - SERVER_TIMEOUT
     - Sets the timeout for requests in the server, uses node's `setTimeout`.
+- SECRET_FILE_PATH
+    - Path to optional azure docker secret file, defaults to `'/run/secrets/azure-uri'`.
+    
+### Docker secrets
+
+Since some of your configuration may contain sensitive data, we have included support for docker secrets for the container_sas value. Read more [here](https://docs.docker.com/engine/swarm/secrets/). Secrets are loaded from a `.json` file and can be placed in a configurable path in the container (SECRET_FILE_PATH environment variable). Take a look at the [docker secrets example](https://docs.docker.com/engine/swarm/secrets/#simple-example-get-started-with-secrets) for further assistance on using docker secrets.
+
 ## Running locally
 To run locally you can use [Azurite](https://github.com/Azure/Azurite). Build and run the Azurite image, create a blob container and generate a SAS url for it. Update the SAS url to use the Azurite's container's IP, and provide this as `CONTAINER_SAS` to the registry's container.

--- a/dockerfiles/azure-blobs-storage/index.ts
+++ b/dockerfiles/azure-blobs-storage/index.ts
@@ -4,25 +4,30 @@ import dynamico from '@dynamico/express-middleware';
 import { AzureBlobStorage } from '@dynamico/azure-blob-storage';
 import { ContainerURL, StorageURL, AnonymousCredential } from '@azure/storage-blob';
 import cors from 'cors';
+import nconf from 'nconf';
+
+const secretsFilePath = process.env.SECRET_FILE_PATH ? process.env.SECRET_FILE_PATH : '/run/secrets/azure-uri';
+
+nconf.file(secretsFilePath).env({ lowerCase: true });
 
 const app = express();
-if (!process.env.CONTAINER_SAS) {
+if (!nconf.get('container_sas')) {
   throw new Error(`Can't start server, missing SAS key`);
 }
 
-const container = new ContainerURL(process.env.CONTAINER_SAS, StorageURL.newPipeline(new AnonymousCredential()));
+const container = new ContainerURL(nconf.get('container_sas'), StorageURL.newPipeline(new AnonymousCredential()));
 const storageProvider = new AzureBlobStorage({
   container,
-  indexBlobName: process.env.INDEX_BLOB_NAME,
-  timeout: Number(process.env.BLOB_DOWNLOAD_TIMEOUT),
-  concurrentConnections: Number(process.env.BLOB_DOWNLOAD_CONCURRENT_CONNECTIONS)
+  indexBlobName: nconf.get('index_blob_name'),
+  timeout: Number(nconf.get('blob_download_timeout')),
+  concurrentConnections: Number(nconf.get('blob_download_concurrent_connections'))
 });
-const serverTimeout = Number(process.env.SERVER_TIMEOUT || 3 * 60 * 1000);
+const serverTimeout = Number(nconf.get('server_timeout') || 3 * 60 * 1000);
 app.use(cors());
-app.use(dynamico(storageProvider, { readOnly: process.env.DYNAMICO_READONLY === 'true' }));
+app.use(dynamico(storageProvider, { readOnly: nconf.get('dynamico_readonly') === 'true' }));
 app.use(jsonErrorHandler({ log: console.log }));
 app.get('/monitoring/healthz', (req, res) => res.sendStatus(200));
-const port = Number(process.env.PORT || 1234);
+const port = Number(nconf.get('port') || 1234);
 app
   .listen(port, () => {
     console.log(`Dynamico Azure Blob Storage registry listening on ${port}`);

--- a/dockerfiles/azure-blobs-storage/package.json
+++ b/dockerfiles/azure-blobs-storage/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-json-error-handler": "^2.0.1",
+    "nconf": "^0.10.0",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.2"
   }

--- a/dockerfiles/redis-azure-blobs/README.md
+++ b/dockerfiles/redis-azure-blobs/README.md
@@ -3,7 +3,7 @@ This is an implementation of a dynamico registry server that uses dynamico Azure
 
 ## Usage
 ### Configuration
-The server uses [nconf](https://github.com/indexzero/nconf) to load configurations. It supports getting configurations through process arguments, a configuration file called `config.json` that is expected to be found in the server's folder or environment variables.
+The server uses [nconf](https://github.com/indexzero/nconf) to load configurations. It supports getting configurations through process arguments, a configuration file called `config.json` that is expected to be found in the server's folder or environment variables. In addition, some sensitive configuration data can be stored in docker secrets for security reasons.
 
 ### Azure Blobs as Components Storage
 The server initializes an instance of `ContainerURL`. To do that it needs a SAS url for the container, that is going to be used to store dynamic components. The key should allow the server to list blobs as well as read and write blobs to the container. You provide the SAS url by setting `container_sas` in your configuration.
@@ -30,5 +30,20 @@ To configure the server you can use these configuration keys:
     - Set the port on which the server will listen to. Defaults to `1234`.
 - server_timeout
     - Sets the timeout for requests in the server, uses node's `setTimeout`.
+
+### Configuration Files
+As mentioned, configuration data can be read from configuration files using these configuration keys:
+
+- CONFIG_FILE_PATH
+    - Sets the `config.json` file location, defaults to root of the project.
+- AZURE_SECRET_FILE_PATH
+    - Path to optional azure docker secret file, defaults to `'/run/secrets/azure-uri'`.
+- REDIS_SECRETS_FILE_PATH
+    - Path to optional redis docker secret file, defaults to `'/run/secrets/redis-config'`.
+
+### Docker secrets
+
+Since some of your configuration may contain sensitive data, we have included support for docker secrets for the container_sas and redis_config values. Read more [here](https://docs.docker.com/engine/swarm/secrets/). Secrets are loaded from a `.json` file and can be placed in a configurable path in the container (AZURE_SECRET_FILE_PATH and REDIS_SECRETS_FILE_PATH environment variables, accordingly). Take a look at the [docker secrets example](https://docs.docker.com/engine/swarm/secrets/#simple-example-get-started-with-secrets) for further assistance on using docker secrets.
+
 ## Running locally
 To run locally you can use [Azurite](https://github.com/Azure/Azurite). Build and run the Azurite image, create a blob container and generate a SAS url for it. Update the SAS url to use the Azurite's container's IP, and provide this as `container_sas` to the registry's container.

--- a/dockerfiles/redis-azure-blobs/index.ts
+++ b/dockerfiles/redis-azure-blobs/index.ts
@@ -11,9 +11,18 @@ import nconf from 'nconf';
 
 const filePath = process.env.CONFIG_FILE_PATH ? process.env.CONFIG_FILE_PATH : './config.json';
 
+const azureSecretsFilePath = process.env.AZURE_SECRET_FILE_PATH
+  ? process.env.AZURE_SECRET_FILE_PATH
+  : '/run/secrets/azure-uri';
+const redisSecretsFilePath = process.env.REDIS_SECRETS_FILE_PATH
+  ? process.env.REDIS_SECRETS_FILE_PATH
+  : '/run/secrets/redis-config';
+
 nconf
   .argv()
-  .file({ file: filePath })
+  .file('azure', azureSecretsFilePath)
+  .file('redis', redisSecretsFilePath)
+  .file('config', filePath)
   .env({ lowerCase: true });
 
 const app = express();

--- a/dockerfiles/s3-registry/.dockerignore
+++ b/dockerfiles/s3-registry/.dockerignore
@@ -8,3 +8,4 @@ Dockerfile
 yarn-error.log
 npm-debug.log
 docker-compose.yml
+access-keys.json

--- a/dockerfiles/s3-registry/README.md
+++ b/dockerfiles/s3-registry/README.md
@@ -23,6 +23,12 @@ To set the behavior of the middleware and configure the `aws-sdk` you can use th
     - If set to `true` makes the middleware run in read only mode. Read more [here]('../../server/express-middleware').
 - PORT
     - Set the port on which the server will listen to. Defaults to `1234`.
+- SECRETS_FILE_PATH
+    - Path to optional s3 access keys file, defaults to `'/run/secrets/s3-access-keys'`.
+
+### Docker secrets
+
+Since some of your configuration may contain sensitive data, we have included support for docker secrets for the ACCESSKEYID and SECRETACCESSKEY values. Read more [here](https://docs.docker.com/engine/swarm/secrets/). Secrets are loaded from a `.json` file and can be placed in a configurable path in the container (SECRETS_FILE_PATH environment variable). Take a look at the [example secrets file](./access-keys.json) which is used by the compose file.
 
 ## Running locally
 You can use the compose file we have here to run the server locally along with an emulator (we use [Minio](https://github.com/minio/minio)). All you have to do is:

--- a/dockerfiles/s3-registry/access-keys.json
+++ b/dockerfiles/s3-registry/access-keys.json
@@ -1,0 +1,4 @@
+{
+  "ACCESSKEYID": "dynamico-access-key",
+  "SECRETACCESSKEY": "dynamico-secret-key"
+}

--- a/dockerfiles/s3-registry/docker-compose.yml
+++ b/dockerfiles/s3-registry/docker-compose.yml
@@ -9,9 +9,9 @@ services:
         - "1234:1234"
       depends_on: 
         - s3-mock
+      secrets:
+        - s3-access-keys
       environment:
-        ACCESSKEYID: dynamico-access-key
-        SECRETACCESSKEY: dynamico-secret-key
         ENDPOINT: "http://s3-mock:9000"
         REGION: "us-east-1"
         FORCEPATHFILE: 'true'
@@ -27,3 +27,6 @@ services:
         MINIO_SECRET_KEY: dynamico-secret-key
       entrypoint: sh
       command: -c 'mkdir -p /data/dynamico && /usr/bin/minio server /data'
+secrets:
+  s3-access-keys:
+    file: ./access-keys.json

--- a/dockerfiles/s3-registry/index.ts
+++ b/dockerfiles/s3-registry/index.ts
@@ -4,32 +4,39 @@ import dynamico from '@dynamico/express-middleware';
 import { S3Storage } from '@dynamico/s3-storage';
 const { S3 } = require('aws-sdk');
 import cors from 'cors';
+import nconf from 'nconf';
 
 const app = express();
+
+const secretsFilePath = process.env.SECRETS_FILE_PATH ? process.env.SECRETS_FILE_PATH : '/run/secrets/s3-access-keys';
+
+nconf.file(secretsFilePath).env();
 
 let s3Config: any = {
   apiVersion: '2006-03-01'
 };
-if (process.env.SECRETACCESSKEY) {
+
+const secretAccessKey = nconf.get('SECRETACCESSKEY');
+if (secretAccessKey) {
   s3Config = {
     ...s3Config,
-    accessKeyId: process.env.ACCESSKEYID,
-    secretAccessKey: process.env.SECRETACCESSKEY,
-    region: process.env.REGION,
-    endpoint: process.env.ENDPOINT,
-    s3ForcePathStyle: process.env.FORCEPATHFILE === 'true'
+    accessKeyId: nconf.get('ACCESSKEYID'),
+    secretAccessKey: secretAccessKey,
+    region: nconf.get('REGION'),
+    endpoint: nconf.get('ENDPOINT'),
+    s3ForcePathStyle: nconf.get('FORCEPATHFILE') === 'true'
   };
 }
 const s3Client = new S3(s3Config);
 
-const bucketName = process.env.BUCKETNAME || 'dynamico';
+const bucketName = nconf.get('BUCKETNAME') || 'dynamico';
 const storageProvider = new S3Storage({ s3Client, bucketName });
 
 app.use(cors());
-app.use(dynamico(storageProvider, { readOnly: process.env.DYNAMICO_READONLY === 'true' }));
+app.use(dynamico(storageProvider, { readOnly: nconf.get('DYNAMICO_READONLY') === 'true' }));
 app.use(jsonErrorHandler({ log: console.log }));
 app.get('/monitoring/healthz', (req, res) => res.sendStatus(200));
-const port = Number(process.env.PORT || 1234);
+const port = Number(nconf.get('PORT') || 1234);
 app.listen(port, () => {
   console.log(`Dynamico S3 registry listening on ${port}`);
 });

--- a/dockerfiles/s3-registry/package.json
+++ b/dockerfiles/s3-registry/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-json-error-handler": "^2.0.1",
+    "nconf": "^0.10.0",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.2"
   }


### PR DESCRIPTION
* Add support to pass sensitive config fields through docker secrets in addition to env variables (for security reasons).
* Configurable docker secrets fields: (s3-registry) access-key-id and secret-access-key.
* Add SECRETS_FILE_PATH env variable to customize secrets location inside the container.

fixes #58 